### PR TITLE
Feature/fc/200/dockerize-flight-computer

### DIFF
--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/Dockerfile
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/Dockerfile
@@ -1,0 +1,5 @@
+FROM raspbian/stretch:latest
+
+COPY piSetup.sh .
+
+RUN ./piSetup.sh

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -1,0 +1,20 @@
+# README.md
+
+cd into folder with Dockerfile
+" docker build -t PI_FC:v1 ."
+" docker run -it -v /c/hyperloop/docker/new/:/home/data raspbian/stretch /bin/bash "
+
+# docker cmds
+docker images -a // list images
+docker ps -a // list containers
+docker run -it <image> bin/bash
+
+# script interpreter error fix // doz2unix equivalent
+"sed -i.bak 's/\r$//' piSetup.sh"
+
+# Remote SSH setup
+turn on ssh via gui
+ifconfig // to get ip address
+Default: user=pi password=raspberry
+
+

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -1,19 +1,19 @@
 # README.md
-install docker // differes per platform, google it
-cd into folder with Dockerfile
-" docker build -t pi_fc:v1 . "
-" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash " 
-// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
+install docker // differes per platform, google it \n
+cd into folder with Dockerfile \n
+" docker build -t pi_fc:v1 . " \n
+" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash "  \n
+// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine \n
 
 # General docker cmds
-docker images -a // list images
-docker ps -a // list containers
-docker run -it <image> bin/bash // run container and open a bash terminal 
+docker images -a // list images \n
+docker ps -a // list containers \n
+docker run -it <image> bin/bash // run container and open a bash terminal  \n
 
 # Fix for script interpreter error // doz2unix equivalent for pi
 "sed -i.bak 's/\r$//' piSetup.sh"
 
 # Remote SSH setup
-turn on ssh via gui
-ifconfig // to get ip address
-Default: user=pi password=raspberry
+turn on ssh via gui \n
+ifconfig // to get ip address \n 
+Default: user=pi password=raspberry \n

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -3,28 +3,28 @@ install docker // differes per platform, google it
 
 cd into folder with Dockerfile
 
-" docker build -t pi_fc:v1 . " 
+`docker build -t pi_fc:v1 .` 
 
-" docker run -it -v path-to-FlightComputer-Dir:/home/data pi_fc:v1 /bin/bash " 
+`docker run -it -v path-to-FlightComputer-Dir:/home/data pi_fc:v1 /bin/bash` 
   
 // path-to-FlightComputer-Dir = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
   
 
 # General docker cmds
-docker images -a // list images 
+`docker images -a` // list images 
 
-docker ps -a // list containers 
+`docker ps -a` // list containers 
 
-docker run -it pi_fc:v1 bin/bash // run container and open a bash terminal 
+`docker run -it pi_fc:v1 bin/bash` // run container and open a bash terminal 
   
 
 # Fix for script interpreter error // doz2unix equivalent for pi
-"sed -i.bak 's/\r$//' piSetup.sh"
+`sed -i.bak 's/\r$//' piSetup.sh`
 
 # Remote SSH setup
 turn on ssh via gui 
 
-ifconfig // to get ip address
+`ifconfig` // to get ip address
 
 Default: user=pi password=raspberry
 

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -1,20 +1,19 @@
 # README.md
-
+install docker // differes per platform, google it
 cd into folder with Dockerfile
-" docker build -t PI_FC:v1 ."
-" docker run -it -v /c/hyperloop/docker/new/:/home/data raspbian/stretch /bin/bash "
+" docker build -t pi_fc:v1 . "
+" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash " 
+// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
 
-# docker cmds
+# General docker cmds
 docker images -a // list images
 docker ps -a // list containers
-docker run -it <image> bin/bash
+docker run -it <image> bin/bash // run container and open a bash terminal 
 
-# script interpreter error fix // doz2unix equivalent
+# Fix for script interpreter error // doz2unix equivalent for pi
 "sed -i.bak 's/\r$//' piSetup.sh"
 
 # Remote SSH setup
 turn on ssh via gui
 ifconfig // to get ip address
 Default: user=pi password=raspberry
-
-

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -5,9 +5,9 @@ cd into folder with Dockerfile
 
 " docker build -t pi_fc:v1 . " 
 
-" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash " 
+" docker run -it -v path-to-FlightComputer-Dir:/home/data pi_fc /bin/bash " 
   
-// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
+// path-to-FlightComputer-Dir = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
   
 
 # General docker cmds
@@ -15,7 +15,7 @@ docker images -a // list images
 
 docker ps -a // list containers 
 
-docker run -it <image> bin/bash // run container and open a bash terminal 
+docker run -it pi_fc:v1 bin/bash // run container and open a bash terminal 
   
 
 # Fix for script interpreter error // doz2unix equivalent for pi

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -1,19 +1,30 @@
 # README.md
-install docker // differes per platform, google it \n
-cd into folder with Dockerfile \n
-" docker build -t pi_fc:v1 . " \n
-" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash "  \n
-// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine \n
+install docker // differes per platform, google it
+
+cd into folder with Dockerfile
+
+" docker build -t pi_fc:v1 . " 
+
+" docker run -it -v <path-to-FlightComputer-Dir>:/home/data pi_fc /bin/bash " 
+  
+// <path-to-FlightComputer-Dir> = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
+  
 
 # General docker cmds
-docker images -a // list images \n
-docker ps -a // list containers \n
-docker run -it <image> bin/bash // run container and open a bash terminal  \n
+docker images -a // list images 
+
+docker ps -a // list containers 
+
+docker run -it <image> bin/bash // run container and open a bash terminal 
+  
 
 # Fix for script interpreter error // doz2unix equivalent for pi
 "sed -i.bak 's/\r$//' piSetup.sh"
 
 # Remote SSH setup
-turn on ssh via gui \n
-ifconfig // to get ip address \n 
-Default: user=pi password=raspberry \n
+turn on ssh via gui 
+
+ifconfig // to get ip address
+
+Default: user=pi password=raspberry
+

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/README.md
@@ -5,7 +5,7 @@ cd into folder with Dockerfile
 
 " docker build -t pi_fc:v1 . " 
 
-" docker run -it -v path-to-FlightComputer-Dir:/home/data pi_fc /bin/bash " 
+" docker run -it -v path-to-FlightComputer-Dir:/home/data pi_fc:v1 /bin/bash " 
   
 // path-to-FlightComputer-Dir = /c/hyperloop/comp5-software/OnPod/FlightComputer on my windows machine
   

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/piSetup.sh
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/piSetup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PI setup script
+echo 'Starting pi setup script'
+
+sudo apt update -y
+sudo apt upgrade -y
+
+sudo apt-get install -y \
+    git \
+    make \
+    curl \
+    xz-utils
+
+# clang++ setup
+cd ~
+wget http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
+tar -xvf clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
+rm clang+llvm-9.0.0-armv7a-linux-gnueabihf.tar.xz
+mv clang+llvm-9.0.0-armv7a-linux-gnueabihf clang_9.0.0
+sudo mv clang_9.0.0 /usr/local
+echo 'export PATH=/usr/local/clang_9.0.0/bin:$PATH' >> .bashrc
+echo 'export LD_LIBRARY_PATH=/usr/local/clang_9.0.0/lib:$LD_LIBRARY_PATH' >> .bashrc
+. .bashrc
+clang++ --version
+# end clang setup
+
+sudo systemctl enable ssh
+sudo systemctl start ssh
+
+echo 'Done pi setup script'

--- a/OnPod/FlightComputer/SetupScriptPlusDockerfile/test_main.cpp
+++ b/OnPod/FlightComputer/SetupScriptPlusDockerfile/test_main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+
+int main()
+{
+    std::cout << "Hello Paradigm\n";
+
+    return 0;
+}


### PR DESCRIPTION
Builds a raspian-stretch docker image with packages from the piSetup.sh, capable of compiling clang++.
Using a script and not straight dockerfile so that we can just use the same script on the PI itself.

The setup script will be expanded with protobuf install instructions and compilation of a new system main in the first comp5 system main pr since other dependencies will likely be required.

This is a base case setup we can branch and build off.